### PR TITLE
[FEAT] 맵 서비스를 위한 REST API 기능 구현

### DIFF
--- a/src/main/java/com/spring/moji/controller/MapRestController.java
+++ b/src/main/java/com/spring/moji/controller/MapRestController.java
@@ -1,0 +1,40 @@
+package com.spring.moji.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.spring.moji.entity.Location;
+import com.spring.moji.entity.Page;
+import com.spring.moji.service.MapService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/map")
+public class MapRestController {
+	private final MapService mapService;
+
+	// 커플 다이어리로 가져오기
+	@GetMapping("/diary/{coupleId}")
+	public List<Location> getDiaryLocations(@PathVariable Long coupleId) {
+		return mapService.getDiaryLocations(coupleId);
+	}
+
+	// 개인 스크랩으로 가져오기
+	@GetMapping("/scrap/mine")
+	public String scrapMine(@RequestParam String email){
+		return null;
+	}
+
+	// 상대 스크랩으로 가져오기
+	@GetMapping("/scrap/partner/{coupleId}")
+	public String scrapPartner(@PathVariable Long coupleId,@RequestParam String email) {
+		return null;
+	}
+}

--- a/src/main/java/com/spring/moji/controller/MapRestController.java
+++ b/src/main/java/com/spring/moji/controller/MapRestController.java
@@ -43,6 +43,6 @@ public class MapRestController {
 	// 단건 페이지 조회
 	@GetMapping("/page/{pageId}")
 	public Page getPage(@PathVariable Long pageId) {
-		return null;
+		return mapService.getPage(pageId);
 	}
 }

--- a/src/main/java/com/spring/moji/controller/MapRestController.java
+++ b/src/main/java/com/spring/moji/controller/MapRestController.java
@@ -28,8 +28,8 @@ public class MapRestController {
 
 	// 개인 스크랩으로 가져오기
 	@GetMapping("/scrap/mine")
-	public String scrapMine(@RequestParam String email){
-		return null;
+	public List<Location> scrapMine(@RequestParam String email){
+		return mapService.getMyScrapLocations(email);
 	}
 
 	// 상대 스크랩으로 가져오기

--- a/src/main/java/com/spring/moji/controller/MapRestController.java
+++ b/src/main/java/com/spring/moji/controller/MapRestController.java
@@ -3,11 +3,13 @@ package com.spring.moji.controller;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.spring.moji.dto.request.MapRequestDTO;
 import com.spring.moji.entity.Location;
 import com.spring.moji.entity.Page;
 import com.spring.moji.service.MapService;
@@ -33,8 +35,14 @@ public class MapRestController {
 	}
 
 	// 상대 스크랩으로 가져오기
-	@GetMapping("/scrap/partner/{coupleId}")
-	public String scrapPartner(@PathVariable Long coupleId,@RequestParam String email) {
+	@GetMapping("/scrap/partner")
+	public List<Location> scrapPartner(@ModelAttribute MapRequestDTO mapRequestDTO) {
+		return mapService.getPartnerScrapLocations(mapRequestDTO);
+	}
+
+	// 단건 페이지 조회
+	@GetMapping("/page/{pageId}")
+	public Page getPage(@PathVariable Long pageId) {
 		return null;
 	}
 }

--- a/src/main/java/com/spring/moji/dto/request/MapRequestDTO.java
+++ b/src/main/java/com/spring/moji/dto/request/MapRequestDTO.java
@@ -1,0 +1,11 @@
+package com.spring.moji.dto.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MapRequestDTO {
+	private Long coupleId;
+	private String email;
+}

--- a/src/main/java/com/spring/moji/entity/Location.java
+++ b/src/main/java/com/spring/moji/entity/Location.java
@@ -3,7 +3,6 @@ package com.spring.moji.entity;
 import java.time.LocalDate;
 import java.util.List;
 
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,8 +29,4 @@ public class Location {
 		this.createdAt = createdAt;
     this.imageUrls = imageUrls;
   }
-
-	public void setPageId(Long pageId) {
-
-	}
 }

--- a/src/main/java/com/spring/moji/mapper/LocationMapper.java
+++ b/src/main/java/com/spring/moji/mapper/LocationMapper.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.spring.moji.dto.request.MapRequestDTO;
 import com.spring.moji.entity.Location;
 
 @Mapper
@@ -14,4 +15,5 @@ public interface LocationMapper {
 	void insertLocation(LocationInsertRequestDTO locationInsertRequestDTO);
 	List<Location> findAllFirstLocation(Long coupleId);
 	List<Location> findScrapedLocations(String email);
+	List<Location> findPartnerScrapedLocations(MapRequestDTO mapRequestDTO);
 }

--- a/src/main/java/com/spring/moji/mapper/LocationMapper.java
+++ b/src/main/java/com/spring/moji/mapper/LocationMapper.java
@@ -12,4 +12,5 @@ import com.spring.moji.entity.Location;
 public interface LocationMapper {
 	List<Location> findAllByPageId(Long pageId);
 	void insertLocation(LocationInsertRequestDTO locationInsertRequestDTO);
+	List<Location> findAllFirstLocation(Long coupleId);
 }

--- a/src/main/java/com/spring/moji/mapper/LocationMapper.java
+++ b/src/main/java/com/spring/moji/mapper/LocationMapper.java
@@ -13,4 +13,5 @@ public interface LocationMapper {
 	List<Location> findAllByPageId(Long pageId);
 	void insertLocation(LocationInsertRequestDTO locationInsertRequestDTO);
 	List<Location> findAllFirstLocation(Long coupleId);
+	List<Location> findScrapedLocations(String email);
 }

--- a/src/main/java/com/spring/moji/mapper/PageMapper.java
+++ b/src/main/java/com/spring/moji/mapper/PageMapper.java
@@ -20,5 +20,6 @@ public interface PageMapper {
 	void deleteByPageId(Long pageId);
 	void insertPage(PageInsertRequestDTO pageInsertRequestDTO);
 	void updatePublicStatusByPageId(PageRequestDTO pageRequestDTO);
-	List<LocalDate> findAllByCoupleId(Long coupleId);
+	List<LocalDate> findDateByCoupleId(Long coupleId);
+	List<Page> findAllByCoupleId(Long communityId);
 }

--- a/src/main/java/com/spring/moji/mapper/PageMapper.java
+++ b/src/main/java/com/spring/moji/mapper/PageMapper.java
@@ -21,5 +21,4 @@ public interface PageMapper {
 	void insertPage(PageInsertRequestDTO pageInsertRequestDTO);
 	void updatePublicStatusByPageId(PageRequestDTO pageRequestDTO);
 	List<LocalDate> findDateByCoupleId(Long coupleId);
-	List<Page> findAllByCoupleId(Long communityId);
 }

--- a/src/main/java/com/spring/moji/service/DiaryServiceImpl.java
+++ b/src/main/java/com/spring/moji/service/DiaryServiceImpl.java
@@ -122,6 +122,6 @@ public class DiaryServiceImpl implements DiaryService {
 
 	@Override
 	public List<LocalDate> getDates(Long coupleId) {
-		return pageMapper.findAllByCoupleId(coupleId);
+		return pageMapper.findDateByCoupleId(coupleId);
 	}
 }

--- a/src/main/java/com/spring/moji/service/MapService.java
+++ b/src/main/java/com/spring/moji/service/MapService.java
@@ -7,6 +7,6 @@ import com.spring.moji.entity.Page;
 
 public interface MapService {
 	public List<Location> getDiaryLocations(Long coupleId);
-	public List<Location> getMyScrapLocations();
+	public List<Location> getMyScrapLocations(String email);
 	public List<Location> getPartnerScrapLocations();
 }

--- a/src/main/java/com/spring/moji/service/MapService.java
+++ b/src/main/java/com/spring/moji/service/MapService.java
@@ -1,0 +1,12 @@
+package com.spring.moji.service;
+
+import java.util.List;
+
+import com.spring.moji.entity.Location;
+import com.spring.moji.entity.Page;
+
+public interface MapService {
+	public List<Location> getDiaryLocations(Long coupleId);
+	public List<Location> getMyScrapLocations();
+	public List<Location> getPartnerScrapLocations();
+}

--- a/src/main/java/com/spring/moji/service/MapService.java
+++ b/src/main/java/com/spring/moji/service/MapService.java
@@ -2,11 +2,13 @@ package com.spring.moji.service;
 
 import java.util.List;
 
+import com.spring.moji.dto.request.MapRequestDTO;
 import com.spring.moji.entity.Location;
 import com.spring.moji.entity.Page;
 
 public interface MapService {
 	public List<Location> getDiaryLocations(Long coupleId);
 	public List<Location> getMyScrapLocations(String email);
-	public List<Location> getPartnerScrapLocations();
+	public List<Location> getPartnerScrapLocations(MapRequestDTO mapRequestDTO);
+	public Page getPage(Long pageId);
 }

--- a/src/main/java/com/spring/moji/service/MapServiceImpl.java
+++ b/src/main/java/com/spring/moji/service/MapServiceImpl.java
@@ -6,6 +6,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.spring.moji.dto.request.MapRequestDTO;
+import com.spring.moji.dto.request.PageRequestDTO;
 import com.spring.moji.entity.Location;
 import com.spring.moji.entity.Page;
 import com.spring.moji.mapper.LocationMapper;
@@ -32,7 +34,12 @@ public class MapServiceImpl implements MapService {
 	}
 
 	@Override
-	public List<Location> getPartnerScrapLocations() {
-		return List.of();
+	public List<Location> getPartnerScrapLocations(MapRequestDTO mapRequestDTO) {
+		return locationMapper.findPartnerScrapedLocations(mapRequestDTO);
+	}
+
+	@Override
+	public Page getPage(Long pageId) {
+		return null;
 	}
 }

--- a/src/main/java/com/spring/moji/service/MapServiceImpl.java
+++ b/src/main/java/com/spring/moji/service/MapServiceImpl.java
@@ -1,13 +1,11 @@
 package com.spring.moji.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.spring.moji.dto.request.MapRequestDTO;
-import com.spring.moji.dto.request.PageRequestDTO;
 import com.spring.moji.entity.Location;
 import com.spring.moji.entity.Page;
 import com.spring.moji.mapper.LocationMapper;
@@ -40,6 +38,6 @@ public class MapServiceImpl implements MapService {
 
 	@Override
 	public Page getPage(Long pageId) {
-		return null;
+		return pageMapper.findByPageId(pageId);
 	}
 }

--- a/src/main/java/com/spring/moji/service/MapServiceImpl.java
+++ b/src/main/java/com/spring/moji/service/MapServiceImpl.java
@@ -27,8 +27,8 @@ public class MapServiceImpl implements MapService {
 	}
 
 	@Override
-	public List<Location> getMyScrapLocations() {
-		return List.of();
+	public List<Location> getMyScrapLocations(String email) {
+		return locationMapper.findScrapedLocations(email);
 	}
 
 	@Override

--- a/src/main/java/com/spring/moji/service/MapServiceImpl.java
+++ b/src/main/java/com/spring/moji/service/MapServiceImpl.java
@@ -1,0 +1,38 @@
+package com.spring.moji.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.spring.moji.entity.Location;
+import com.spring.moji.entity.Page;
+import com.spring.moji.mapper.LocationMapper;
+import com.spring.moji.mapper.PageMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MapServiceImpl implements MapService {
+	private final PageMapper pageMapper;
+	private final LocationMapper locationMapper;
+
+	@Override
+	public List<Location> getDiaryLocations(Long coupleId) {
+		List<Location> locations = locationMapper.findAllFirstLocation(coupleId);
+		return locations;
+	}
+
+	@Override
+	public List<Location> getMyScrapLocations() {
+		return List.of();
+	}
+
+	@Override
+	public List<Location> getPartnerScrapLocations() {
+		return List.of();
+	}
+}

--- a/src/main/resources/mapper/LocationMapper.xml
+++ b/src/main/resources/mapper/LocationMapper.xml
@@ -63,4 +63,36 @@
 				ORDER BY p.page_id
 		</select>
 
+		<select id="findScrapedLocations" parameterType="String" resultMap="LocationResultMap">
+				SELECT
+						l.location_id,
+						l.page_id,
+						l.address,
+						l.latitude,
+						l.longitude,
+						l.created_at AS location_created_at,
+						iu.image_url_id,
+						iu.location_id AS image_location_id,
+						iu.map_image,
+						iu.created_at AS image_url_created_at
+				FROM (
+								 SELECT page_id, diary_id, created_at
+								 FROM pages
+								 WHERE page_id IN (
+										 SELECT page_id
+										 FROM scraps
+										 WHERE email = #{email}
+								 )
+						 ) p
+								 LEFT JOIN (
+						SELECT l.*, ROW_NUMBER() OVER (PARTITION BY l.page_id ORDER BY l.created_at ASC) AS rn
+						FROM locations l
+				) l ON p.page_id = l.page_id AND l.rn = 1
+								 LEFT JOIN (
+						SELECT iu.*, ROW_NUMBER() OVER (PARTITION BY iu.location_id ORDER BY iu.created_at ASC) AS rn
+						FROM image_urls iu
+				) iu ON l.location_id = iu.location_id AND iu.rn = 1
+				WHERE l.location_id IS NOT NULL
+				ORDER BY p.created_at
+		</select>
 </mapper>

--- a/src/main/resources/mapper/LocationMapper.xml
+++ b/src/main/resources/mapper/LocationMapper.xml
@@ -2,6 +2,21 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.spring.moji.mapper.LocationMapper">
+		<resultMap id="LocationResultMap" type="com.spring.moji.entity.Location">
+				<id property="locationId" column="location_id"/>
+				<result property="pageId" column="page_id"/>
+				<result property="address" column="address"/>
+				<result property="latitude" column="latitude"/>
+				<result property="longitude" column="longitude"/>
+				<result property="createdAt" column="location_created_at"/>
+				<collection property="imageUrls" ofType="com.spring.moji.entity.ImageUrl">
+						<id property="imageUrlId" column="image_url_id"/>
+						<result property="locationId" column="image_location_id"/>
+						<result property="mapImage" column="map_image"/>
+						<result property="createdAt" column="image_url_created_at"/>
+				</collection>
+		</resultMap>
+
    <select id="findAllByPageId" parameterType="java.lang.Long" resultType="com.spring.moji.entity.Location">
        select *
        from locations
@@ -15,5 +30,37 @@
     VALUES (#{pageId}, #{address}, #{latitude}, #{longitude}, sysdate)
   </insert>
 
+		<select id="findAllFirstLocation" parameterType="java.lang.Long" resultMap="LocationResultMap">
+				SELECT
+						l.location_id,
+						l.page_id,
+						l.address,
+						l.latitude,
+						l.longitude,
+						l.created_at AS location_created_at,
+						iu.image_url_id,
+						iu.location_id AS image_location_id,
+						iu.map_image,
+						iu.created_at AS image_url_created_at
+				FROM (
+								 SELECT page_id, diary_id
+								 FROM pages
+								 WHERE diary_id = (
+										 SELECT diary_id
+										 FROM diaries
+										 WHERE couple_id = #{coupleId}
+								 )
+						 ) p
+								 LEFT JOIN (
+						SELECT l.*, ROW_NUMBER() OVER (PARTITION BY l.page_id ORDER BY l.created_at ASC) AS rn
+						FROM locations l
+				) l ON p.page_id = l.page_id AND l.rn = 1
+								 LEFT JOIN (
+						SELECT iu.*, ROW_NUMBER() OVER (PARTITION BY iu.location_id ORDER BY iu.created_at ASC) AS rn
+						FROM image_urls iu
+				) iu ON l.location_id = iu.location_id AND iu.rn = 1
+				WHERE l.location_id IS NOT NULL
+				ORDER BY p.page_id
+		</select>
 
 </mapper>

--- a/src/main/resources/mapper/LocationMapper.xml
+++ b/src/main/resources/mapper/LocationMapper.xml
@@ -95,4 +95,47 @@
 				WHERE l.location_id IS NOT NULL
 				ORDER BY p.created_at
 		</select>
+
+		<select id="findPartnerScrapedLocations" parameterType="com.spring.moji.dto.request.MapRequestDTO" resultMap="LocationResultMap">
+				SELECT
+						l.location_id,
+						l.page_id,
+						l.address,
+						l.latitude,
+						l.longitude,
+						l.created_at AS location_created_at,
+						iu.image_url_id,
+						iu.location_id AS image_location_id,
+						iu.map_image,
+						iu.created_at AS image_url_created_at
+				FROM (
+								 SELECT page_id, diary_id, created_at
+								 FROM pages
+								 WHERE page_id IN (
+										 SELECT page_id
+										 FROM scraps
+										 WHERE email = (
+												 SELECT
+														 CASE
+																 WHEN user1_email = #{email} THEN user2_email
+																 WHEN user2_email = #{email} THEN user1_email
+																 ELSE NULL
+																 END AS other_email
+												 FROM couples
+												 WHERE couple_id = #{coupleId}
+													 AND (user1_email = #{email} OR user2_email = #{email})
+										 )
+								 )
+						 ) p
+								 LEFT JOIN (
+						SELECT l.*, ROW_NUMBER() OVER (PARTITION BY l.page_id ORDER BY l.created_at ASC) AS rn
+						FROM locations l
+				) l ON p.page_id = l.page_id AND l.rn = 1
+								 LEFT JOIN (
+						SELECT iu.*, ROW_NUMBER() OVER (PARTITION BY iu.location_id ORDER BY iu.created_at ASC) AS rn
+						FROM image_urls iu
+				) iu ON l.location_id = iu.location_id AND iu.rn = 1
+				WHERE l.location_id IS NOT NULL
+				ORDER BY p.created_at
+		</select>
 </mapper>

--- a/src/main/resources/mapper/PageMapper.xml
+++ b/src/main/resources/mapper/PageMapper.xml
@@ -184,7 +184,7 @@
 			UPDATE pages SET public_status = #{publicStatus} WHERE page_id = #{pageId}
 		</update>
 
-		<select id="findAllByCoupleId" parameterType="java.lang.Long" resultType="java.time.LocalDate">
+		<select id="findDateByCoupleId" parameterType="java.lang.Long" resultType="java.time.LocalDate">
 				select distinct created_at
 				from pages
 				where diary_id = (select diary_id


### PR DESCRIPTION
**PR 타입(하나 이상의 PR 타입을 선택해주세요)**
-[V] 기능 추가 -[] 기능 삭제 -[] 버그 수정 -[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

**반영 브랜치**
feature/98-be-scrap-map-rest-api -> develop

**변경 사항**
맵 서비스 구현을 위한 REST API 기능 구현
- 다이어리 내 작성한 페이지에 따른 위치, 이미지 조회
- 유저가 스크랩한 페이지의 위치, 이미지 조회
- 유저의 커플이 스크랩한 페이지의 위치, 이미지 조회
- 단건 페이지 조회